### PR TITLE
Add macOS build fix, Linux PGXS support, and dependency notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,23 @@
-# general config
-MODULES = pg_math
-EXTENSION = pg_math
-DATA = pg_math--1.0.sql
+#############################
+# Makefile for pg_math
+#############################
 
-# postgres build config
-PG_CONFIG = pg_config
+EXTENSION   = pg_math
+MODULE_big  = pg_math
+OBJS        = pg_math.o
+DATA        = pg_math--1.0.sql
+PGFILEDESC  = "pg_math - with GNU Scientific Library"
+
+# Homebrew prefix autodetection
+BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+
+# Include and lib paths
+PG_CPPFLAGS += -I$(BREW_PREFIX)/include -I$(BREW_PREFIX)/opt/gsl/include
+SHLIB_LINK  += -L$(BREW_PREFIX)/lib -L$(BREW_PREFIX)/opt/openblas/lib \
+               -Wl,-rpath,$(BREW_PREFIX)/lib -Wl,-rpath,$(BREW_PREFIX)/opt/openblas/lib \
+               -lgsl -lgslcblas -lm
+
+# PGXS build (standalone)
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-
-LDFLAGS = -lgsl -lgslcblas -lm

--- a/README.md
+++ b/README.md
@@ -171,20 +171,19 @@ pg_math is a C extension that utilises the GSL (GNU Scientific Library) to suppo
 
 [libgsl](https://www.gnu.org/software/gsl/) (GSL - GNU Scientific Library) package is required to compile this extension.
 
-For Ubuntu:
+**macOS (Homebrew):**
+   ```bash
+   brew install gsl openblas pkg-config
+   ```
+   Requires PostgreSQL (installed separately via Homebrew or system package).
 
-    sudo apt-get install libgsl-dev
-    
-For Fedora:
+**Linux:**
+   ```bash
+   sudo apt install gcc libgsl-dev libopenblas-dev pkg-config
+   ```
+   PostgreSQL (dev headers and binaries) must be installed beforehand.
 
-    sudo dnf -y install gsl
-or
 
-    sudo yum -y install gsl
-    
-For Mac:
-
-    brew install gsl
     
 ## Installation
 
@@ -206,9 +205,3 @@ For Mac:
 
     select cdf_gaussian_qinv(0.05,5);
  
-## Future development
-
-1. Regression tests
-
-2. Multi-column aggregates to perform statistics
-


### PR DESCRIPTION
Extension now builds cleanly across macOS (Home brew) and Linux (PostgreSQL dev packages) using a unified Makefile and PGXS workflow.

- Fixed macOS build issues by aligning GSL and OpenBLAS linking with Homebrew paths.
- Ensured compatibility with Linux builds using PGXS and pg_config for automatic PostgreSQL detection.
- Updated README with dependency installation instructions for macOS and Linux environments.